### PR TITLE
Fix for gcc compilation

### DIFF
--- a/gcodemillopt/gcodemillopt.cpp
+++ b/gcodemillopt/gcodemillopt.cpp
@@ -162,8 +162,8 @@ public:
 
 //
 // Sorting...
-bool SortLessPair(std::pair<std::vector<GCodeSet>::size_type, double> &left, 
-	std::pair<std::vector<GCodeSet>::size_type, double> &right) 
+bool SortLessPair(const std::pair<std::vector<GCodeSet>::size_type, double> &left, 
+	const std::pair<std::vector<GCodeSet>::size_type, double> &right) 
 {
 	return left.second < right.second;
 }


### PR DESCRIPTION
This software can be compiled under GNU/Linux (and other OSs, I suppose) with gcc, provided that this change is made (otherwise a compile-time error is returned).

Also, for gcc compilation, the option -std=gnu++11 must be specified in the command line.
